### PR TITLE
uint256

### DIFF
--- a/bandersnatch/fieldElements/modulus.go
+++ b/bandersnatch/fieldElements/modulus.go
@@ -1,0 +1,429 @@
+package fieldElements
+
+import (
+	"math/bits"
+
+)
+
+// Modulus contains a modulus `m` as well as derived values that help speed up computations.
+// The allowed range for `m` is `2^192` to `2^256-1`.
+type Modulus struct{
+	m    [4]uint64 // modulus
+	mu   [5]uint64 // reciprocal
+	mmu0 [4]uint64 // m*(mu/2^256 + 0)
+	mmu1 [4]uint64 // m*(mu/2^256 + 1) % 2^256
+}
+
+func (z *Modulus) ModulusFromUint64 (m [4]uint64){
+
+	if m[3] == 0 {
+		panic("Modulus < 2^192")
+	}
+
+	// Store the modulus itself
+	z = &Modulus{m: m}
+
+	// Compute reciprocal of m
+	z.mu = reciprocal(m)
+
+	// Compute mmu0, mmu1
+
+	mmu0(z)
+	mmu1(z)
+}
+
+// ToUint64 returns an array with the modulus.
+func (z *Modulus) ToUint64() [4]uint64 {
+	return z.m
+}
+
+// reciprocal computes a 320-bit value mu representing 2^512/m
+// (or equivalently 1/m in a 0.320-bit fixed point representation)
+//
+// Notes:
+// - starts with a 32-bit division, refines with newton-raphson iterations
+// - mu * m < 2^512
+// - mu * m + m >= 2^512
+// - mu * m + m == 2^512 iff m is a power of 2
+func reciprocal(m [4]uint64) (mu [5]uint64) {
+
+	// Note: specialized for m[3] != 0
+
+	s := bits.LeadingZeros64(m[3])
+	p := 63 - s
+
+	// 0 or a power of 2?
+
+	// Check if at least one bit is set in m[2], m[1] or m[0],
+	// or at least two bits in m[3]
+	// If not, m is 0 or a power of 2
+
+	if m[0] | m[1] | m[2] | (m[3] & (m[3]-1)) == 0 {
+		mu[4] = ^uint64(0) >> uint(p & 63)
+		mu[3] = ^uint64(0)
+		mu[2] = ^uint64(0)
+		mu[1] = ^uint64(0)
+		mu[0] = ^uint64(0)
+
+		return mu
+	}
+
+	// Maximise division precision by left-aligning divisor
+
+	var (
+		y  [4]uint64 // left-aligned copy of m
+		r0 uint32    // estimate of 2^31/y
+	)
+
+	y = shiftleft256(m, uint(s))	// 1/2 < y < 1
+
+	// Extract most significant 32 bits
+
+	yh := uint32(y[3] >> 32)
+
+
+	if yh == 0x80000000 { // Avoid overflow in division
+		r0 = 0xffffffff
+	} else {
+		r0, _ = bits.Div32(0x80000000, 0, yh)
+	}
+
+	// First iteration: 32 -> 64
+
+	t1 := uint64(r0)		// 2^31/y
+	t1 *= t1			// 2^62/y^2
+	t1, _ = bits.Mul64(t1, y[3])	// 2^62/y^2 * 2^64/y / 2^64 = 2^62/y
+
+	r1 := uint64(r0) << 32		// 2^63/y
+	r1 -= t1			// 2^63/y - 2^62/y = 2^62/y
+	r1 *= 2				// 2^63/y
+
+	if (r1 | (y[3]<<1)) == 0 {
+		r1 = ^uint64(0)
+	}
+
+	// Second iteration: 64 -> 128
+
+	// square: 2^126/y^2
+	a2h, a2l := bits.Mul64(r1, r1)
+
+	// multiply by y: e2h:e2l:b2h = 2^126/y^2 * 2^128/y / 2^128 = 2^126/y
+	b2h, _   := bits.Mul64(a2l, y[2])
+	c2h, c2l := bits.Mul64(a2l, y[3])
+	d2h, d2l := bits.Mul64(a2h, y[2])
+	e2h, e2l := bits.Mul64(a2h, y[3])
+
+	b2h, c   := bits.Add64(b2h, c2l, 0)
+	e2l, c    = bits.Add64(e2l, c2h, c)
+	e2h, _    = bits.Add64(e2h,   0, c)
+
+	_,   c    = bits.Add64(b2h, d2l, 0)
+	e2l, c    = bits.Add64(e2l, d2h, c)
+	e2h, _    = bits.Add64(e2h,   0, c)
+
+	// subtract: t2h:t2l = 2^127/y - 2^126/y = 2^126/y
+	t2l, b   := bits.Sub64( 0, e2l, 0)
+	t2h, _   := bits.Sub64(r1, e2h, b)
+
+	// double: r2h:r2l = 2^127/y
+	r2l, c   := bits.Add64(t2l, t2l, 0)
+	r2h, _   := bits.Add64(t2h, t2h, c)
+
+	if (r2h | r2l | (y[3]<<1)) == 0 {
+		r2h = ^uint64(0)
+		r2l = ^uint64(0)
+	}
+
+	// Third iteration: 128 -> 192
+
+	// square r2 (keep 256 bits): 2^190/y^2
+	a3h, a3l := bits.Mul64(r2l, r2l)
+	b3h, b3l := bits.Mul64(r2l, r2h)
+	c3h, c3l := bits.Mul64(r2h, r2h)
+
+	a3h, c    = bits.Add64(a3h, b3l, 0)
+	c3l, c    = bits.Add64(c3l, b3h, c)
+	c3h, _    = bits.Add64(c3h,   0, c)
+
+	a3h, c    = bits.Add64(a3h, b3l, 0)
+	c3l, c    = bits.Add64(c3l, b3h, c)
+	c3h, _    = bits.Add64(c3h,   0, c)
+
+	// multiply by y: q = 2^190/y^2 * 2^192/y / 2^192 = 2^190/y
+
+	x0 := a3l
+	x1 := a3h
+	x2 := c3l
+	x3 := c3h
+
+	var q0, q1, q2, q3, q4, t0 uint64
+
+	q0, _  = bits.Mul64(x2, y[0])
+	q1, t0 = bits.Mul64(x3, y[0]); q0, c = bits.Add64(q0, t0, 0); q1, _ = bits.Add64(q1,  0, c)
+
+
+	t1, _  = bits.Mul64(x1, y[1]); q0, c = bits.Add64(q0, t1, 0)
+	q2, t0 = bits.Mul64(x3, y[1]); q1, c = bits.Add64(q1, t0, c); q2, _ = bits.Add64(q2,  0, c)
+
+	t1, t0 = bits.Mul64(x2, y[1]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c); q2, _ = bits.Add64(q2, 0, c)
+
+
+	t1, t0 = bits.Mul64(x1, y[2]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c)
+	q3, t0 = bits.Mul64(x3, y[2]); q2, c = bits.Add64(q2, t0, c); q3, _ = bits.Add64(q3,  0, c)
+
+	t1, _  = bits.Mul64(x0, y[2]); q0, c = bits.Add64(q0, t1, 0)
+	t1, t0 = bits.Mul64(x2, y[2]); q1, c = bits.Add64(q1, t0, c); q2, c = bits.Add64(q2, t1, c); q3, _ = bits.Add64(q3, 0, c)
+
+
+	t1, t0 = bits.Mul64(x1, y[3]); q1, c = bits.Add64(q1, t0, 0); q2, c = bits.Add64(q2, t1, c)
+	q4, t0 = bits.Mul64(x3, y[3]); q3, c = bits.Add64(q3, t0, c); q4, _ = bits.Add64(q4,  0, c)
+
+	t1, t0 = bits.Mul64(x0, y[3]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c)
+	t1, t0 = bits.Mul64(x2, y[3]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c); q4, _ = bits.Add64(q4, 0, c)
+
+	// subtract: t3 = 2^191/y - 2^190/y = 2^190/y
+	_,   b  = bits.Sub64(  0, q0, 0)
+	_,   b  = bits.Sub64(  0, q1, b)
+	t3l, b := bits.Sub64(  0, q2, b)
+	t3m, b := bits.Sub64(r2l, q3, b)
+	t3h, _ := bits.Sub64(r2h, q4, b)
+
+	// double: r3 = 2^191/y
+	r3l, c := bits.Add64(t3l, t3l, 0)
+	r3m, c := bits.Add64(t3m, t3m, c)
+	r3h, _ := bits.Add64(t3h, t3h, c)
+
+	// Fourth iteration: 192 -> 320
+
+	// square r3
+
+	a4h, a4l := bits.Mul64(r3l, r3l)
+	b4h, b4l := bits.Mul64(r3l, r3m)
+	c4h, c4l := bits.Mul64(r3l, r3h)
+	d4h, d4l := bits.Mul64(r3m, r3m)
+	e4h, e4l := bits.Mul64(r3m, r3h)
+	f4h, f4l := bits.Mul64(r3h, r3h)
+
+	b4h, c = bits.Add64(b4h, c4l, 0)
+	e4l, c = bits.Add64(e4l, c4h, c)
+	e4h, _ = bits.Add64(e4h,   0, c)
+
+	a4h, c = bits.Add64(a4h, b4l, 0)
+	d4l, c = bits.Add64(d4l, b4h, c)
+	d4h, c = bits.Add64(d4h, e4l, c)
+	f4l, c = bits.Add64(f4l, e4h, c)
+	f4h, _ = bits.Add64(f4h,   0, c)
+
+	a4h, c = bits.Add64(a4h, b4l, 0)
+	d4l, c = bits.Add64(d4l, b4h, c)
+	d4h, c = bits.Add64(d4h, e4l, c)
+	f4l, c = bits.Add64(f4l, e4h, c)
+	f4h, _ = bits.Add64(f4h,   0, c)
+
+	// multiply by y
+
+	x1, x0  = bits.Mul64(d4h, y[0])
+	x3, x2  = bits.Mul64(f4h, y[0])
+	t1, t0  = bits.Mul64(f4l, y[0]); x1, c = bits.Add64(x1, t0, 0); x2, c = bits.Add64(x2, t1, c)
+							         x3, _ = bits.Add64(x3,  0, c)
+
+	t1, t0  = bits.Mul64(d4h, y[1]); x1, c = bits.Add64(x1, t0, 0); x2, c = bits.Add64(x2, t1, c)
+	x4, t0 := bits.Mul64(f4h, y[1]); x3, c = bits.Add64(x3, t0, c); x4, _ = bits.Add64(x4,  0, c)
+	t1, t0  = bits.Mul64(d4l, y[1]); x0, c = bits.Add64(x0, t0, 0); x1, c = bits.Add64(x1, t1, c)
+	t1, t0  = bits.Mul64(f4l, y[1]); x2, c = bits.Add64(x2, t0, c); x3, c = bits.Add64(x3, t1, c)
+							      x4, _ = bits.Add64(x4,  0, c)
+
+	t1, t0  = bits.Mul64(a4h, y[2]); x0, c = bits.Add64(x0, t0, 0); x1, c = bits.Add64(x1, t1, c)
+	t1, t0  = bits.Mul64(d4h, y[2]); x2, c = bits.Add64(x2, t0, c); x3, c = bits.Add64(x3, t1, c)
+	x5, t0 := bits.Mul64(f4h, y[2]); x4, c = bits.Add64(x4, t0, c); x5, _ = bits.Add64(x5,  0, c)
+	t1, t0  = bits.Mul64(d4l, y[2]); x1, c = bits.Add64(x1, t0, 0); x2, c = bits.Add64(x2, t1, c)
+	t1, t0  = bits.Mul64(f4l, y[2]); x3, c = bits.Add64(x3, t0, c); x4, c = bits.Add64(x4, t1, c)
+							      x5, _ = bits.Add64(x5,  0, c)
+
+	t1, t0  = bits.Mul64(a4h, y[3]); x1, c = bits.Add64(x1, t0, 0); x2, c = bits.Add64(x2, t1, c)
+	t1, t0  = bits.Mul64(d4h, y[3]); x3, c = bits.Add64(x3, t0, c); x4, c = bits.Add64(x4, t1, c)
+	x6, t0 := bits.Mul64(f4h, y[3]); x5, c = bits.Add64(x5, t0, c); x6, _ = bits.Add64(x6,  0, c)
+	t1, t0  = bits.Mul64(a4l, y[3]); x0, c = bits.Add64(x0, t0, 0); x1, c = bits.Add64(x1, t1, c)
+	t1, t0  = bits.Mul64(d4l, y[3]); x2, c = bits.Add64(x2, t0, c); x3, c = bits.Add64(x3, t1, c)
+	t1, t0  = bits.Mul64(f4l, y[3]); x4, c = bits.Add64(x4, t0, c); x5, c = bits.Add64(x5, t1, c)
+							      x6, _ = bits.Add64(x6,  0, c)
+
+	// subtract
+	_,   b	 = bits.Sub64(  0, x0, 0)
+	_,   b	 = bits.Sub64(  0, x1, b)
+	r4l, b	:= bits.Sub64(  0, x2, b)
+	r4k, b	:= bits.Sub64(  0, x3, b)
+	r4j, b	:= bits.Sub64(r3l, x4, b)
+	r4i, b	:= bits.Sub64(r3m, x5, b)
+	r4h, _	:= bits.Sub64(r3h, x6, b)
+
+	// Multiply candidate for 1/4y by y, with full precision
+
+	x0 = r4l
+	x1 = r4k
+	x2 = r4j
+	x3 = r4i
+	x4 = r4h
+
+	q1, q0	 = bits.Mul64(x0, y[0])
+	q3, q2	 = bits.Mul64(x2, y[0])
+	q5, q4	:= bits.Mul64(x4, y[0])
+
+	t1, t0	 = bits.Mul64(x1, y[0]); q1, c = bits.Add64(q1, t0, 0); q2, c = bits.Add64(q2, t1, c)
+	t1, t0	 = bits.Mul64(x3, y[0]); q3, c = bits.Add64(q3, t0, c); q4, c = bits.Add64(q4, t1, c); q5, _ = bits.Add64(q5, 0, c)
+
+	t1, t0	 = bits.Mul64(x0, y[1]); q1, c = bits.Add64(q1, t0, 0); q2, c = bits.Add64(q2, t1, c)
+	t1, t0	 = bits.Mul64(x2, y[1]); q3, c = bits.Add64(q3, t0, c); q4, c = bits.Add64(q4, t1, c)
+	q6, t0	:= bits.Mul64(x4, y[1]); q5, c = bits.Add64(q5, t0, c); q6, _ = bits.Add64(q6,  0, c)
+
+	t1, t0	 = bits.Mul64(x1, y[1]); q2, c = bits.Add64(q2, t0, 0); q3, c = bits.Add64(q3, t1, c)
+	t1, t0	 = bits.Mul64(x3, y[1]); q4, c = bits.Add64(q4, t0, c); q5, c = bits.Add64(q5, t1, c); q6, _ = bits.Add64(q6, 0, c)
+
+	t1, t0	 = bits.Mul64(x0, y[2]); q2, c = bits.Add64(q2, t0, 0); q3, c = bits.Add64(q3, t1, c)
+	t1, t0	 = bits.Mul64(x2, y[2]); q4, c = bits.Add64(q4, t0, c); q5, c = bits.Add64(q5, t1, c)
+	q7, t0	:= bits.Mul64(x4, y[2]); q6, c = bits.Add64(q6, t0, c); q7, _ = bits.Add64(q7,  0, c)
+
+	t1, t0	 = bits.Mul64(x1, y[2]); q3, c = bits.Add64(q3, t0, 0); q4, c = bits.Add64(q4, t1, c)
+	t1, t0	 = bits.Mul64(x3, y[2]); q5, c = bits.Add64(q5, t0, c); q6, c = bits.Add64(q6, t1, c); q7, _ = bits.Add64(q7, 0, c)
+
+	t1, t0	 = bits.Mul64(x0, y[3]); q3, c = bits.Add64(q3, t0, 0); q4, c = bits.Add64(q4, t1, c)
+	t1, t0	 = bits.Mul64(x2, y[3]); q5, c = bits.Add64(q5, t0, c); q6, c = bits.Add64(q6, t1, c)
+	q8, t0	:= bits.Mul64(x4, y[3]); q7, c = bits.Add64(q7, t0, c); q8, _ = bits.Add64(q8,  0, c)
+
+	t1, t0	 = bits.Mul64(x1, y[3]); q4, c = bits.Add64(q4, t0, 0); q5, c = bits.Add64(q5, t1, c)
+	t1, t0	 = bits.Mul64(x3, y[3]); q6, c = bits.Add64(q6, t0, c); q7, c = bits.Add64(q7, t1, c); q8, _ = bits.Add64(q8, 0, c)
+
+	// Final adjustments: increment/decrement the result to get the correct reciprocal
+
+	// subtract q from 1/4
+	q0, b = bits.Sub64(0, q0, 0)
+	q1, b = bits.Sub64(0, q1, b)
+	q2, b = bits.Sub64(0, q2, b)
+	q3, b = bits.Sub64(0, q3, b)
+	q4, b = bits.Sub64(0, q4, b)
+	q5, b = bits.Sub64(0, q5, b)
+	q6, b = bits.Sub64(0, q6, b)
+	q7, b = bits.Sub64(0, q7, b)
+	q8, b = bits.Sub64(uint64(1) << 62, q8, b)
+
+	// decrement the result
+	x0, t := bits.Sub64(r4l, 1, 0)
+	x1, t  = bits.Sub64(r4k, 0, t)
+	x2, t  = bits.Sub64(r4j, 0, t)
+	x3, t  = bits.Sub64(r4i, 0, t)
+	x4, _  = bits.Sub64(r4h, 0, t)
+
+	// commit the decrement if the subtraction underflowed (reciprocal was too large)
+	if b != 0 {
+		r4h, r4i, r4j, r4k, r4l = x4, x3, x2, x1, x0
+	}
+
+	// subtract y from q
+	q0, b = bits.Sub64(q0, y[0], 0)
+	q1, b = bits.Sub64(q1, y[1], b)
+	q2, b = bits.Sub64(q2, y[2], b)
+	q3, b = bits.Sub64(q3, y[3], b)
+	q4, b = bits.Sub64(q4,    0, b)
+	q5, b = bits.Sub64(q5,    0, b)
+	q6, b = bits.Sub64(q6,    0, b)
+	q7, b = bits.Sub64(q7,    0, b)
+	q8, b = bits.Sub64(q8,    0, b)
+
+	// increment the result
+	x0, t = bits.Add64(r4l, 1, 0)
+	x1, t = bits.Add64(r4k, 0, t)
+	x2, t = bits.Add64(r4j, 0, t)
+	x3, t = bits.Add64(r4i, 0, t)
+	x4, _ = bits.Add64(r4h, 0, t)
+
+	// commit the increment if the subtraction did not underflow (reciprocal was too small)
+	if b == 0 {
+		r4h, r4i, r4j, r4k, r4l = x4, x3, x2, x1, x0
+	}
+
+	// Shift to correct bit alignment, truncating excess bits
+
+	p = p - 1
+
+	x0, c = bits.Add64(r4l, r4l, 0)
+	x1, c = bits.Add64(r4k, r4k, c)
+	x2, c = bits.Add64(r4j, r4j, c)
+	x3, c = bits.Add64(r4i, r4i, c)
+	x4, _ = bits.Add64(r4h, r4h, c)
+
+	if p < 0 {
+		r4h, r4i, r4j, r4k, r4l = x4, x3, x2, x1, x0
+		p = 0	// avoid negative shift below
+	}
+
+	// Shift right 0-62 bits
+	{
+		r := uint(p)		// right shift
+		l := uint(64 - r)	// left shift
+
+		x0 = (r4l >> r) | (r4k << l)
+		x1 = (r4k >> r) | (r4j << l)
+		x2 = (r4j >> r) | (r4i << l)
+		x3 = (r4i >> r) | (r4h << l)
+		x4 = (r4h >> r)
+	}
+
+	if p > 0 {
+		r4h, r4i, r4j, r4k, r4l = x4, x3, x2, x1, x0
+	}
+
+	mu[0] = r4l
+	mu[1] = r4k
+	mu[2] = r4j
+	mu[3] = r4i
+	mu[4] = r4h
+
+	return mu
+}
+
+func mmu0(z *Modulus) {
+	var c, t0, t1, q0, q1, q2, q3, q4 uint64
+
+	q2, q1 = bits.Mul64(z.m[1], z.mu[4])
+	q4, q3 = bits.Mul64(z.m[3], z.mu[4])
+
+	t1, q0 = bits.Mul64(z.m[0], z.mu[4]); q1, c = bits.Add64(q1, t1, 0)
+	t1, t0 = bits.Mul64(z.m[2], z.mu[4]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c); q4, _ = bits.Add64(q4, 0, c)
+
+	if q4 != 0 {
+		panic("Error preparing mmu0")
+	}
+
+	z.mmu0 = [4]uint64{ q0, q1, q2, q3 }
+
+}
+
+func mmu1(z *Modulus) {
+	var c uint64
+
+	z.mmu1[0], c = bits.Add64(z.mmu0[0], z.m[0], 0)
+	z.mmu1[1], c = bits.Add64(z.mmu0[1], z.m[1], c)
+	z.mmu1[2], c = bits.Add64(z.mmu0[2], z.m[2], c)
+	z.mmu1[3], c = bits.Add64(z.mmu0[3], z.m[3], c)
+
+	// mmu0 is the largest multiple of m such that mmu0 < 2^256
+	// mmu1 is the smallest multiple of m such that mmu1 >= 2^256
+	// => there must be a carry out from the addition above
+
+	if c != 1 {
+		panic("Error preparing mmu1")
+	}
+}
+
+// shiftleft256 shifts the 256-bit value in a little-endian array left by 0-63 bits.
+func shiftleft256(x [4]uint64, s uint) (z [4]uint64) {
+	l := s % 64	// left shift
+	r := 64 - l	// right shift
+
+	z[0] = (x[0] << l)
+	z[1] = (x[1] << l) | (x[0] >> r)
+	z[2] = (x[2] << l) | (x[1] >> r)
+	z[3] = (x[3] << l) | (x[2] >> r)
+
+	return z
+}

--- a/bandersnatch/fieldElements/uint256.go
+++ b/bandersnatch/fieldElements/uint256.go
@@ -10,6 +10,14 @@ import (
 
 type uint256 [4]uint64 // low-endian
 
+var m Modulus
+
+
+func init(){
+	//initialize modulus precomputations to improve speed
+	m.ModulusFromUint64([4]uint64{baseFieldSize_0, baseFieldSize_1, baseFieldSize_2, baseFieldSize_3})
+}
+
 func (z *uint256) ToBigInt() *big.Int {
 	var big_endian_byte_slice [32]byte
 	binary.BigEndian.PutUint64(big_endian_byte_slice[0:8], z[3])
@@ -23,6 +31,12 @@ func BigIntToUInt256(x *big.Int) (result uint256) {
 	return utils.BigIntToUIntArray(x)
 }
 
+// ToUint64 returns an array with the canonical representative of the residue class.
+func (z *uint256) ToUint64() [4]uint64 {
+	z.reduce4() // Reduce to canonical residue
+	return [4]uint64{z[0], z[1], z[2], z[3]}
+}
+
 // Add computes an addition z := x + y.
 // The addition is carried out modulo 2^256
 func (z *uint256) Add(x, y *uint256) {
@@ -33,6 +47,9 @@ func (z *uint256) Add(x, y *uint256) {
 	z[3], _ = bits.Add64(x[3], y[3], carry)
 }
 
+// AddWithCarry computes an addition z := x + y.
+// The addition is carried out modulo 2^256
+// Returns the carry value
 func (z *uint256) AddWithCarry(x, y *uint256) (carry uint64) {
 	z[0], carry = bits.Add64(x[0], y[0], 0)
 	z[1], carry = bits.Add64(x[1], y[1], carry)
@@ -41,6 +58,7 @@ func (z *uint256) AddWithCarry(x, y *uint256) (carry uint64) {
 	return
 }
 
+// Sub computes subtraction x := x - y, modulo 2^256
 func (z *uint256) Sub(x, y *uint256) {
 	var borrow uint64 // only takes values 0,1
 	z[0], borrow = bits.Sub64(x[0], y[0], 0)
@@ -49,6 +67,8 @@ func (z *uint256) Sub(x, y *uint256) {
 	z[3], _ = bits.Sub64(x[3], y[3], borrow)
 }
 
+// SubWithBorrow computes subtraction x := x - y, modulo 2^256
+// returns borrow bit
 func (z *uint256) SubWithBorrow(x, y *uint256) (borrow uint64) {
 	z[0], borrow = bits.Sub64(x[0], y[0], 0)
 	z[1], borrow = bits.Sub64(x[1], y[1], borrow)
@@ -87,6 +107,42 @@ func (z *uint256) AddAndReduce_Weak(x, y *uint256) {
 		z[3], _ = bits.Sub64(z[3], baseFieldSize_3, carry) // _ is guaranteed to be 0
 	}
 }
+
+// Add computes the sum of two residues, strong reduce
+func (z *uint256) AddDg(x *uint256) *uint256 {
+	t0, c := bits.Add64(z[0], x[0], 0)
+	t1, c := bits.Add64(z[1], x[1], c)
+	t2, c := bits.Add64(z[2], x[2], c)
+	t3, c := bits.Add64(z[3], x[3], c)
+
+	u0, b := bits.Sub64(t0, m.mmu1[0], 0)
+	u1, b := bits.Sub64(t1, m.mmu1[1], b)
+	u2, b := bits.Sub64(t2, m.mmu1[2], b)
+	u3, _ := bits.Sub64(t3, m.mmu1[3], b)
+
+	v0, b := bits.Sub64(t0, m.mmu0[0], 0)
+	v1, b := bits.Sub64(t1, m.mmu0[1], b)
+	v2, b := bits.Sub64(t2, m.mmu0[2], b)
+	v3, b := bits.Sub64(t3, m.mmu0[3], b)
+
+	// Subtract the larger multiple of m if necessary
+
+	if b == 0 {
+		v3, v2, v1, v0 = u3, u2, u1, u0
+	}
+
+	// Subtract if overflow
+
+	if c != 0 {
+		t3, t2, t1, t0 = v3, v2, v1, v0
+	}
+
+	z[3], z[2], z[1], z[0] = t3, t2, t1, t0
+
+	return z
+}
+
+
 
 // SubAndReduce_Weak1 sets z, such that z==x-y mod BaseFieldSize holds.
 // Assumes x and y to be weakly reduced in [0, UINT256MAX-BaseFieldSize).
@@ -155,6 +211,42 @@ func (z *uint256) SubAndReduce_Weak2(x, y *uint256) {
 	}
 }
 
+// Sub computes the sum of a residue and the negation of a second residue.
+func (z *uint256) SubDg(x *uint256) *uint256 {
+	t0, b := bits.Sub64(z[0], x[0], 0)
+	t1, b := bits.Sub64(z[1], x[1], b)
+	t2, b := bits.Sub64(z[2], x[2], b)
+	t3, b := bits.Sub64(z[3], x[3], b)
+
+	u0, c := bits.Add64(t0, m.mmu1[0], 0)
+	u1, c := bits.Add64(t1, m.mmu1[1], c)
+	u2, c := bits.Add64(t2, m.mmu1[2], c)
+	u3, _ := bits.Add64(t3, m.mmu1[3], c)
+
+	v0, c := bits.Add64(t0, m.mmu0[0], 0)
+	v1, c := bits.Add64(t1, m.mmu0[1], c)
+	v2, c := bits.Add64(t2, m.mmu0[2], c)
+	v3, c := bits.Add64(t3, m.mmu0[3], c)
+
+	// Add the larger multiple of m if necessary
+
+	if c == 0 {
+		v3, v2, v1, v0 = u3, u2, u1, u0
+	}
+
+	// Add if underflow
+
+	if b != 0 {
+		t3, t2, t1, t0 = v3, v2, v1, v0
+	}
+
+	z[3], z[2], z[1], z[0] = t3, t2, t1, t0
+
+	return z
+}
+
+
+
 // IsZero checks whether the uint256 is (exactly) zero.
 func (z *uint256) IsZero() bool {
 	return z[0]|z[1]|z[2]|z[3] == 0
@@ -204,4 +296,556 @@ func (z *uint256) is_fully_reduced() bool {
 	}
 	// if we get here, z.words == BaseFieldSize
 	return false
+}
+
+
+// Inv computes the multiplicative Inverse:
+//
+// z.Inv(x) performs z:= 1/x. If x is 0, the behaviour is undefined (possibly panic)
+func (z *uint256) Inv(X *uint256) bool{
+	var (
+		b, c, // Borrow & carry
+		a4, a3, a2, a1, a0,
+		b4, b3, b2, b1, b0,
+		c4, c3, c2, c1, c0,
+		d4, d3, d2, d1, d0 uint64
+	)
+
+	x := X
+	y := m.m
+
+	u3, u2, u1, u0 := x[3], x[2], x[1], x[0]
+	v3, v2, v1, v0 := y[3], y[2], y[1], y[0]
+
+	// there is no inverse
+	if (u3 | u2 | u1 | u0) == 0 ||	// u == 0
+	   (v3 | v2 | v1 | v0) == 0 ||	// v == 0
+	   (u0 | v0) & 1 == 0 {		    // 2|gcd(u,v)
+		
+		z[3], z[2], z[1], z[0] = 0, 0, 0, 0
+		return false
+	}
+
+	a4, a3, a2, a1, a0 = 0, 0, 0, 0, 1
+	b4, b3, b2, b1, b0 = 0, 0, 0, 0, 0
+	c4, c3, c2, c1, c0 = 0, 0, 0, 0, 0
+	d4, d3, d2, d1, d0 = 0, 0, 0, 0, 1
+
+	done := false
+
+	for !done {
+		for u0 & 1 == 0 {
+
+			u0 = (u0 >> 1) | (u1 << 63)
+			u1 = (u1 >> 1) | (u2 << 63)
+			u2 = (u2 >> 1) | (u3 << 63)
+			u3 = (u3 >> 1)
+
+			if (a0 | b0) & 1 == 1 {
+
+				a0, c = bits.Add64(a0, y[0], 0)
+				a1, c = bits.Add64(a1, y[1], c)
+				a2, c = bits.Add64(a2, y[2], c)
+				a3, c = bits.Add64(a3, y[3], c)
+				a4, _ = bits.Add64(a4,    0, c)
+
+				b0, b = bits.Sub64(b0, x[0], 0)
+				b1, b = bits.Sub64(b1, x[1], b)
+				b2, b = bits.Sub64(b2, x[2], b)
+				b3, b = bits.Sub64(b3, x[3], b)
+				b4, _ = bits.Sub64(b4,    0, b)
+			}
+
+			a0 = (a0 >> 1) | (a1 << 63)
+			a1 = (a1 >> 1) | (a2 << 63)
+			a2 = (a2 >> 1) | (a3 << 63)
+			a3 = (a3 >> 1) | (a4 << 63)
+			a4 = uint64(int64(a4) >> 1)
+
+			b0 = (b0 >> 1) | (b1 << 63)
+			b1 = (b1 >> 1) | (b2 << 63)
+			b2 = (b2 >> 1) | (b3 << 63)
+			b3 = (b3 >> 1) | (b4 << 63)
+			b4 = uint64(int64(b4) >> 1)
+		}
+
+		for v0 & 1 == 0 {
+
+			v0 = (v0 >> 1) | (v1 << 63)
+			v1 = (v1 >> 1) | (v2 << 63)
+			v2 = (v2 >> 1) | (v3 << 63)
+			v3 = (v3 >> 1)
+
+			if (c0 | d0) & 1 == 1 {
+
+				c0, c = bits.Add64(c0, y[0], 0)
+				c1, c = bits.Add64(c1, y[1], c)
+				c2, c = bits.Add64(c2, y[2], c)
+				c3, c = bits.Add64(c3, y[3], c)
+				c4, _ = bits.Add64(c4,    0, c)
+
+				d0, b = bits.Sub64(d0, x[0], 0)
+				d1, b = bits.Sub64(d1, x[1], b)
+				d2, b = bits.Sub64(d2, x[2], b)
+				d3, b = bits.Sub64(d3, x[3], b)
+				d4, _ = bits.Sub64(d4,    0, b)
+			}
+
+			c0 = (c0 >> 1) | (c1 << 63)
+			c1 = (c1 >> 1) | (c2 << 63)
+			c2 = (c2 >> 1) | (c3 << 63)
+			c3 = (c3 >> 1) | (c4 << 63)
+			c4 = uint64(int64(c4) >> 1)
+
+			d0 = (d0 >> 1) | (d1 << 63)
+			d1 = (d1 >> 1) | (d2 << 63)
+			d2 = (d2 >> 1) | (d3 << 63)
+			d3 = (d3 >> 1) | (d4 << 63)
+			d4 = uint64(int64(d4) >> 1)
+		}
+
+		t0, b := bits.Sub64(u0, v0, 0)
+		t1, b := bits.Sub64(u1, v1, b)
+		t2, b := bits.Sub64(u2, v2, b)
+		t3, b := bits.Sub64(u3, v3, b)
+
+		if b == 0 { // u >= v
+
+			u3, u2, u1, u0 = t3, t2, t1, t0
+
+			a0, b = bits.Sub64(a0, c0, 0)
+			a1, b = bits.Sub64(a1, c1, b)
+			a2, b = bits.Sub64(a2, c2, b)
+			a3, b = bits.Sub64(a3, c3, b)
+			a4, _ = bits.Sub64(a4, c4, b)
+
+			b0, b = bits.Sub64(b0, d0, 0)
+			b1, b = bits.Sub64(b1, d1, b)
+			b2, b = bits.Sub64(b2, d2, b)
+			b3, b = bits.Sub64(b3, d3, b)
+			b4, _ = bits.Sub64(b4, d4, b)
+
+		} else { // v > u
+
+			v0, b = bits.Sub64(v0, u0, 0)
+			v1, b = bits.Sub64(v1, u1, b)
+			v2, b = bits.Sub64(v2, u2, b)
+			v3, _ = bits.Sub64(v3, u3, b)
+
+			c0, b = bits.Sub64(c0, a0, 0)
+			c1, b = bits.Sub64(c1, a1, b)
+			c2, b = bits.Sub64(c2, a2, b)
+			c3, b = bits.Sub64(c3, a3, b)
+			c4, _ = bits.Sub64(c4, a4, b)
+
+			d0, b = bits.Sub64(d0, b0, 0)
+			d1, b = bits.Sub64(d1, b1, b)
+			d2, b = bits.Sub64(d2, b2, b)
+			d3, b = bits.Sub64(d3, b3, b)
+			d4, _ = bits.Sub64(d4, b4, b)
+		}
+
+		if (u3 | u2 | u1 | u0) == 0 {
+			done = true
+		}
+	}
+
+	if (v3 | v2 | v1 | (v0 - 1)) != 0 { // gcd(z,m) != 1
+		z[3], z[2], z[1], z[0] = 0, 0, 0, 0
+		return false
+	}
+
+	// Add or subtract modulus to find 256-bit inverse (<= 2 iterations expected)
+
+	for (c4 >> 63) != 0 {
+		c0, c = bits.Add64(c0, y[0], 0)
+		c1, c = bits.Add64(c1, y[1], c)
+		c2, c = bits.Add64(c2, y[2], c)
+		c3, c = bits.Add64(c3, y[3], c)
+		c4, _ = bits.Add64(c4,    0, c)
+	}
+
+	for c4 != 0 {
+		c0, b = bits.Sub64(c0, y[0], 0)
+		c1, b = bits.Sub64(c1, y[1], b)
+		c2, b = bits.Sub64(c2, y[2], b)
+		c3, b = bits.Sub64(c3, y[3], b)
+		c4, _ = bits.Sub64(c4,    0, b)
+	}
+
+	z[3], z[2], z[1], z[0] = c3, c2, c1, c0
+	return true
+}
+
+
+func (z *uint256) Mul(x *uint256) *uint256 {
+	if z == x {
+		z.Square()
+		return z
+	}
+	// Multiplication
+
+	var c, t0, t1, q0, q1, q2, q3, q4, q5, q6, q7 uint64
+
+	q2, q1 = bits.Mul64(z[0], x[1])
+	q4, q3 = bits.Mul64(z[0], x[3])
+
+	t1, q0 = bits.Mul64(z[0], x[0]); q1, c = bits.Add64(q1, t1, 0)
+	t1, t0 = bits.Mul64(z[0], x[2]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c); q4, _ = bits.Add64(q4, 0, c)
+
+	t1, t0 = bits.Mul64(z[1], x[1]); q2, c = bits.Add64(q2, t0, 0); q3, c = bits.Add64(q3, t1, c)
+	q5, t0 = bits.Mul64(z[1], x[3]); q4, c = bits.Add64(q4, t0, c); q5, _ = bits.Add64(q5,  0, c)
+
+	t1, t0 = bits.Mul64(z[1], x[0]); q1, c = bits.Add64(q1, t0, 0); q2, c = bits.Add64(q2, t1, c)
+	t1, t0 = bits.Mul64(z[1], x[2]); q3, c = bits.Add64(q3, t0, c); q4, c = bits.Add64(q4, t1, c); q5, _ = bits.Add64(q5, 0, c)
+
+	t1, t0 = bits.Mul64(z[2], x[1]); q3, c = bits.Add64(q3, t0, 0); q4, c = bits.Add64(q4, t1, c)
+	q6, t0 = bits.Mul64(z[2], x[3]); q5, c = bits.Add64(q5, t0, c); q6, _ = bits.Add64(q6,  0, c)
+
+	t1, t0 = bits.Mul64(z[2], x[0]); q2, c = bits.Add64(q2, t0, 0); q3, c = bits.Add64(q3, t1, c)
+	t1, t0 = bits.Mul64(z[2], x[2]); q4, c = bits.Add64(q4, t0, c); q5, c = bits.Add64(q5, t1, c); q6, _ = bits.Add64(q6, 0, c)
+
+	t1, t0 = bits.Mul64(z[3], x[1]); q4, c = bits.Add64(q4, t0, 0); q5, c = bits.Add64(q5, t1, c)
+	q7, t0 = bits.Mul64(z[3], x[3]); q6, c = bits.Add64(q6, t0, c); q7, _ = bits.Add64(q7,  0, c)
+
+	t1, t0 = bits.Mul64(z[3], x[0]); q3, c = bits.Add64(q3, t0, 0); q4, c = bits.Add64(q4, t1, c)
+	t1, t0 = bits.Mul64(z[3], x[2]); q5, c = bits.Add64(q5, t0, c); q6, c = bits.Add64(q6, t1, c); q7, _ = bits.Add64(q7, 0, c)
+
+	// Reduction
+
+	z.reduce8([8]uint64{ q0, q1, q2, q3, q4, q5, q6, q7 })
+
+	return z
+}
+
+// Square squares the field element, computing z = x * x
+//
+// z.Square(&x) is equivalent to z.Mul(&x, &x)
+func (z *uint256) Square(){
+	var c, t0, t1, q0, q1, q2, q3, q4, q5, q6, q7 uint64
+
+	q4, q3 = bits.Mul64(z[0], z[3])
+
+	t1, q2 = bits.Mul64(z[0], z[2]); q3, c = bits.Add64(q3, t1, 0)
+	q5, t0 = bits.Mul64(z[1], z[3]); q4, c = bits.Add64(q4, t0, c); q5, c = bits.Add64(q5, 0, c)
+
+	t1, q1 = bits.Mul64(z[0], z[1]); q2, c = bits.Add64(q2, t1, 0)
+	t1, t0 = bits.Mul64(z[1], z[2]); q3, c = bits.Add64(q3, t0, c); q4, c = bits.Add64(q4, t1, c)
+	q6, t0 = bits.Mul64(z[2], z[3]); q5, c = bits.Add64(q5, t0, c); q6, c = bits.Add64(q6, 0, c)
+
+	q1, c = bits.Add64(q1, q1, 0)
+	q2, c = bits.Add64(q2, q2, c)
+	q3, c = bits.Add64(q3, q3, c)
+	q4, c = bits.Add64(q4, q4, c)
+	q5, c = bits.Add64(q5, q5, c)
+	q6, c = bits.Add64(q6, q6, c)
+	q7, _ = bits.Add64( 0,  0, c)
+
+	t1, q0 = bits.Mul64(z[0], z[0]); q1, c = bits.Add64(q1, t1, 0)
+	t1, t0 = bits.Mul64(z[1], z[1]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c)
+	t1, t0 = bits.Mul64(z[2], z[2]); q4, c = bits.Add64(q4, t0, c); q5, c = bits.Add64(q5, t1, c)
+	t1, t0 = bits.Mul64(z[3], z[3]); q6, c = bits.Add64(q6, t0, c); q7, _ = bits.Add64(q7, t1, c)
+
+	// Reduction
+
+	z.reduce8([8]uint64{ q0, q1, q2, q3, q4, q5, q6, q7 })
+}
+
+
+//Barrett reduction in the Handbook of Applied Cryptography.
+func (z *uint256) reduce8(x [8]uint64){
+	// q1 = x/2^192
+	x0 := x[3]
+	x1 := x[4]
+	x2 := x[5]
+	x3 := x[6]
+	x4 := x[7]
+
+	// q2 = q1 * mu; q3 = q2 / 2^320
+
+	var q0, q1, q2, q3, q4, q5, t0, t1, c uint64
+
+	q0, _  = bits.Mul64(x3, m.mu[0])
+	q1, t0 = bits.Mul64(x4, m.mu[0]); q0, c = bits.Add64(q0, t0, 0); q1, _ = bits.Add64(q1,  0, c)
+
+
+	t1, _  = bits.Mul64(x2, m.mu[1]); q0, c = bits.Add64(q0, t1, 0)
+	q2, t0 = bits.Mul64(x4, m.mu[1]); q1, c = bits.Add64(q1, t0, c); q2, _ = bits.Add64(q2,  0, c)
+
+	t1, t0 = bits.Mul64(x3, m.mu[1]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c); q2, _ = bits.Add64(q2, 0, c)
+
+
+	t1, t0 = bits.Mul64(x2, m.mu[2]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c)
+	q3, t0 = bits.Mul64(x4, m.mu[2]); q2, c = bits.Add64(q2, t0, c); q3, _ = bits.Add64(q3,  0, c)
+
+	t1, _  = bits.Mul64(x1, m.mu[2]); q0, c = bits.Add64(q0, t1, 0)
+	t1, t0 = bits.Mul64(x3, m.mu[2]); q1, c = bits.Add64(q1, t0, c); q2, c = bits.Add64(q2, t1, c); q3, _ = bits.Add64(q3, 0, c)
+
+
+	t1, _  = bits.Mul64(x0, m.mu[3]); q0, c = bits.Add64(q0, t1, 0)
+	t1, t0 = bits.Mul64(x2, m.mu[3]); q1, c = bits.Add64(q1, t0, c); q2, c = bits.Add64(q2, t1, c)
+	q4, t0 = bits.Mul64(x4, m.mu[3]); q3, c = bits.Add64(q3, t0, c); q4, _ = bits.Add64(q4,  0, c)
+
+	t1, t0 = bits.Mul64(x1, m.mu[3]); q0, c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c)
+	t1, t0 = bits.Mul64(x3, m.mu[3]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c); q4, _ = bits.Add64(q4, 0, c)
+
+
+	t1, t0 = bits.Mul64(x0, m.mu[4]); _,  c = bits.Add64(q0, t0, 0); q1, c = bits.Add64(q1, t1, c)
+	t1, t0 = bits.Mul64(x2, m.mu[4]); q2, c = bits.Add64(q2, t0, c); q3, c = bits.Add64(q3, t1, c)
+	q5, t0 = bits.Mul64(x4, m.mu[4]); q4, c = bits.Add64(q4, t0, c); q5, _ = bits.Add64(q5,  0, c)
+
+	t1, t0 = bits.Mul64(x1, m.mu[4]); q1, c = bits.Add64(q1, t0, 0); q2, c = bits.Add64(q2, t1, c)
+	t1, t0 = bits.Mul64(x3, m.mu[4]); q3, c = bits.Add64(q3, t0, c); q4, c = bits.Add64(q4, t1, c); q5, _ = bits.Add64(q5, 0, c)
+
+	// Drop the fractional part of q3
+
+	q0 = q1
+	q1 = q2
+	q2 = q3
+	q3 = q4
+	q4 = q5
+
+	// r1 = x mod 2^320
+
+	x0 = x[0]
+	x1 = x[1]
+	x2 = x[2]
+	x3 = x[3]
+	x4 = x[4]
+
+	// r2 = q3 * m mod 2^320
+
+	var r0, r1, r2, r3, r4 uint64
+
+	r4, r3 = bits.Mul64(q0, m.mu[3])
+	_,  t0 = bits.Mul64(q1, m.mu[3]); r4, _ = bits.Add64(r4, t0, 0)
+
+
+	t1, r2 = bits.Mul64(q0, m.mu[2]); r3, c = bits.Add64(r3, t1, 0)
+	_,  t0 = bits.Mul64(q2, m.mu[2]); r4, _ = bits.Add64(r4, t0, c)
+
+	t1, t0 = bits.Mul64(q1, m.mu[2]); r3, c = bits.Add64(r3, t0, 0); r4, _ = bits.Add64(r4, t1, c)
+
+
+	t1, r1 = bits.Mul64(q0, m.mu[1]); r2, c = bits.Add64(r2, t1, 0)
+	t1, t0 = bits.Mul64(q2, m.mu[1]); r3, c = bits.Add64(r3, t0, c); r4, _ = bits.Add64(r4, t1, c)
+
+	t1, t0 = bits.Mul64(q1, m.mu[1]); r2, c = bits.Add64(r2, t0, 0); r3, c = bits.Add64(r3, t1, c)
+	_,  t0 = bits.Mul64(q3, m.mu[1]); r4, _ = bits.Add64(r4, t0, c)
+
+
+	t1, r0 = bits.Mul64(q0, m.mu[0]); r1, c = bits.Add64(r1, t1, 0)
+	t1, t0 = bits.Mul64(q2, m.mu[0]); r2, c = bits.Add64(r2, t0, c); r3, c = bits.Add64(r3, t1, c)
+	_,  t0 = bits.Mul64(q4, m.mu[0]); r4, _ = bits.Add64(r4, t0, c)
+
+	t1, t0 = bits.Mul64(q1, m.mu[0]); r1, c = bits.Add64(r1, t0, 0); r2, c = bits.Add64(r2, t1, c)
+	t1, t0 = bits.Mul64(q3, m.mu[0]); r3, c = bits.Add64(r3, t0, c); r4, _ = bits.Add64(r4, t1, c)
+
+
+	// r = r1 - r2
+
+	var b uint64
+
+	r0, b = bits.Sub64(x0, r0, 0)
+	r1, b = bits.Sub64(x1, r1, b)
+	r2, b = bits.Sub64(x2, r2, b)
+	r3, b = bits.Sub64(x3, r3, b)
+	r4, b = bits.Sub64(x4, r4, b)
+
+	// if r<0 then r+=m
+
+	x0, c = bits.Add64(r0, m.m[0], 0)
+	x1, c = bits.Add64(r1, m.m[1], c)
+	x2, c = bits.Add64(r2, m.m[2], c)
+	x3, c = bits.Add64(r3, m.m[3], c)
+	x4, _ = bits.Add64(r4, 0, c)
+
+	// commit if borrow
+	if b != 0 {
+		r4, r3, r2, r1, r0 = x4, x3, x2, x1, x0
+	}
+
+	// incomplete reduction is possible if m < 2^256/3
+	if m.m[3] < 0x5555555555555555 {
+		z[3], z[2], z[1], z[0] = r3, r2, r1, r0
+		return 
+	}
+
+	// q = r - m
+	x0, b = bits.Sub64(r0, m.m[0], 0)
+	x1, b = bits.Sub64(r1, m.m[1], b)
+	x2, b = bits.Sub64(r2, m.m[2], b)
+	x3, b = bits.Sub64(r3, m.m[3], b)
+	x4, b = bits.Sub64(r4,    0, b)
+
+	// commit if no borrow
+	if b == 0 {
+		r4, r3, r2, r1, r0 = x4, x3, x2, x1, x0
+	}
+
+	// q = r - m
+	x0, b = bits.Sub64(r0, m.m[0], 0)
+	x1, b = bits.Sub64(r1, m.m[1], b)
+	x2, b = bits.Sub64(r2, m.m[2], b)
+	x3, b = bits.Sub64(r3, m.m[3], b)
+	x4, b = bits.Sub64(r4,    0, b)
+
+	// commit if no borrow
+	if b == 0 {
+		r4, r3, r2, r1, r0 = x4, x3, x2, x1, x0
+	}
+
+	z[3], z[2], z[1], z[0] = r3, r2, r1, r0
+
+}
+
+
+// reduce4 computes the least non-negative residue of z
+// and stores it back in z
+func (z *uint256) reduce4() *uint256 {
+
+	// NB: Most variable names in the comments match the pseudocode for
+	// 	Barrett reduction in the Handbook of Applied Cryptography.
+
+	var x0, x1, x2, x3, x4, r0, r1, r2, r3, r4, q3, t0, t1, c uint64
+
+	mu := m.mu
+	m  := m.m
+
+	// q1 = x/2^192
+	// q2 = q1 * mu; q3 = q2 / 2^320
+
+	q3, _ = bits.Mul64(z[3], mu[4])
+
+	// r1 = x mod 2^320 = x
+
+	x0 = z[0]
+	x1 = z[1]
+	x2 = z[2]
+	x3 = z[3]
+	x4 = 0
+
+	// r2 = q3 * m mod 2^320
+
+	r2, r1 = bits.Mul64(q3, m[1])
+	r4, r3 = bits.Mul64(q3, m[3])
+
+	t1, r0 = bits.Mul64(q3, m[0]); r1, c = bits.Add64(r1, t1, 0)
+	t1, t0 = bits.Mul64(q3, m[2]); r2, c = bits.Add64(r2, t0, c); r3, c = bits.Add64(r3, t1, c); r4, _ = bits.Add64(r4, 0, c)
+
+	// r = r1 - r2 = x - r2
+
+	// Note: x < 2^256
+	//    => q3 <= x/m
+	//    => q3*m <= x
+	//    => r2 <= x
+	//    => r >= 0
+
+	var b uint64
+
+	r0, b = bits.Sub64(x0, r0, 0)
+	r1, b = bits.Sub64(x1, r1, b)
+	r2, b = bits.Sub64(x2, r2, b)
+	r3, b = bits.Sub64(x3, r3, b)
+	r4, _ = bits.Sub64(x4, r4, b)
+
+	for {
+		// if r>=m then r-=m
+
+		x0, b = bits.Sub64(r0, m[0], 0)
+		x1, b = bits.Sub64(r1, m[1], b)
+		x2, b = bits.Sub64(r2, m[2], b)
+		x3, b = bits.Sub64(r3, m[3], b)
+		x4, b = bits.Sub64(r4,    0, b)
+
+		if b != 0 {
+			break
+		}
+
+		// commit if no borrow (r1 >= r2 + m)
+
+		r4, r3, r2, r1, r0 = x4, x3, x2, x1, x0
+	}
+
+	z[3], z[2], z[1], z[0] = r3, r2, r1, r0
+
+	return z
+}
+
+// Neg computes the negation (additive inverse) of a residue.
+func (z *uint256) Neg() *uint256 {
+	t0, b := bits.Sub64(m.mmu1[0], z[0], 0)
+	t1, b := bits.Sub64(m.mmu1[1], z[1], b)
+	t2, b := bits.Sub64(m.mmu1[2], z[2], b)
+	t3, _ := bits.Sub64(m.mmu1[3], z[3], b)
+
+	u0, b := bits.Sub64(m.mmu0[0], z[0], 0)
+	u1, b := bits.Sub64(m.mmu0[1], z[1], b)
+	u2, b := bits.Sub64(m.mmu0[2], z[2], b)
+	u3, b := bits.Sub64(m.mmu0[3], z[3], b)
+
+	if b != 0 {
+		u3, u2, u1, u0 = t3, t2, t1, t0
+	}
+
+	z[3], z[2], z[1], z[0] = u3, u2, u1, u0
+
+	return z
+}
+
+// Double computes the double of a residue.
+func (z *uint256) Double() *uint256 {
+
+	t0, c := bits.Add64(z[0], z[0], 0)
+	t1, c := bits.Add64(z[1], z[1], c)
+	t2, c := bits.Add64(z[2], z[2], c)
+	t3, c := bits.Add64(z[3], z[3], c)
+
+	u0, b := bits.Sub64(t0, m.mmu1[0], 0)
+	u1, b := bits.Sub64(t1, m.mmu1[1], b)
+	u2, b := bits.Sub64(t2, m.mmu1[2], b)
+	u3, _ := bits.Sub64(t3, m.mmu1[3], b)
+
+	v0, b := bits.Sub64(t0, m.mmu0[0], 0)
+	v1, b := bits.Sub64(t1, m.mmu0[1], b)
+	v2, b := bits.Sub64(t2, m.mmu0[2], b)
+	v3, b := bits.Sub64(t3, m.mmu0[3], b)
+
+	// Subtract the larger multiple of m if necessary
+
+	if b == 0 {
+		v3, v2, v1, v0 = u3, u2, u1, u0
+	}
+
+	// Subtract if overflow
+
+	if c != 0 {
+		t3, t2, t1, t0 = v3, v2, v1, v0
+	}
+
+	z[3], z[2], z[1], z[0] = t3, t2, t1, t0
+
+	return z
+}
+////////////////////////
+//comparison functions//
+////////////////////////
+
+
+// Equal compares one residue to another, returns true when equal.
+func (x *uint256) Equal(y *uint256) bool {
+	x.reduce4()
+	y.reduce4()
+
+	r := x[0] ^ y[0]
+	r |= x[1] ^ y[1]
+	r |= x[2] ^ y[2]
+	r |= x[3] ^ y[3]
+
+	return r == 0
+}
+
+// NotEqual compares one residue to another, returns true when different.
+func (x *uint256) NotEqual(y *uint256) bool {
+	return !(x.Equal(y))
 }


### PR DESCRIPTION
Based on Dag's code, the following was added:

```go
func init()
func (z *uint256) ToUint64() [4]uint64
func (z *uint256) AddDg(x *uint256) *uint256
func (z *uint256) SubDg(x *uint256) *uint256
func (z *uint256) Inv(X *uint256) boo
func (z *uint256) Mul(x *uint256) *uint256
func (z *uint256) Square(
func (z *uint256) reduce8(x [8]uint64
func (z *uint256) reduce4() *uint256
func (z *uint256) Neg() *uint256
func (z *uint256) Double() *uint256
//comparison functions//
func (x *uint256) Equal(y *uint256) bool
func (x *uint256) NotEqual(y *uint256) bool
```

As well as modulus functions in  ```modulus.go```

This is untested code, just meant as reference. I will be working on making tests and bench for it.
